### PR TITLE
Fix some syntax errors in the tutorial

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -252,7 +252,7 @@ For instance, this example will create a ``full_name`` column from the ``first_n
 .. code-block:: python
 
     full_names = exonerations.compute([
-        ('full_name', agate.Formula(text_type, lambda row: '%(first_name)s %(last_name)s' % row)
+        ('full_name', agate.Formula(text_type, lambda row: '%(first_name)s %(last_name)s' % row))
     ])
 
 For efficiencies sake, agate allows you to perform several computations at once.
@@ -260,8 +260,8 @@ For efficiencies sake, agate allows you to perform several computations at once.
 .. code-block:: python
 
     with_computations = exonerations.compute([
-        ('years_in_prison', agate.Change('convicted', 'exonerated')),
-        ('full_name', agate.Formula(text_type, lambda row: '%(first_name)s %(last_name)s' % row)
+        ('full_name', agate.Formula(text_type, lambda row: '%(first_name)s %(last_name)s' % row)),
+        ('years_in_prison', agate.Change('convicted', 'exonerated'))
     ])
 
 If :class:`.Formula` still is not flexible enough (for instance, if you need to compute a new row based on the distribution of data in a column) you can always implement your own subclass of :class:`.Computation`. See the API documentation for :mod:`.computations` to see all of the supported ways to compute new data.
@@ -331,7 +331,7 @@ This takes our original :class:`.Table` and groups it into a :class:`.TableSet`,
 
     state_totals = by_state.aggregate()
 
-    sorted_totals = totals.order_by('count', reverse=True)
+    sorted_totals = state_totals.order_by('count', reverse=True)
 
     print(sorted_totals.format(max_rows=5))
 
@@ -364,8 +364,8 @@ This is a much more complicated question that's going to pull together a lot of 
 
     state_totals = with_years_in_prison.group_by('state')
 
-    medians = totals.aggregate([
-        ('years_in_prison', Median(), 'median_years_in_prison')
+    medians = state_totals.aggregate([
+        ('years_in_prison', agate.Median(), 'median_years_in_prison')
     ])
 
     sorted_medians = medians.order_by('median_years_in_prison', reverse=True)


### PR DESCRIPTION
Just ran through the tutorial and came across a few small errors. Fixed 'em.

One related thing that is weird and maybe deserving of a separate issue: Putting the `agate.Formula` second in the list of computations appeared to make agate try to cast it as a decimal, which failed. I swapped the order in the tutorial to get it to work (since the same formula worked fine when it was the only list item), but seems like an issue with the type specification.

Here's a stack trace:

```python
In [51]: with_computations = exonerations.compute([
('years_in_prison', agate.Change('convicted', 'exonerated')),
('full_name', agate.Formula(text_type, lambda row: '%(first_name)s %(last_name)s' % row))
])
---------------------------------------------------------------------------
CastError                                 Traceback (most recent call last)
<ipython-input-51-2560a46849b8> in <module>()
      1 with_computations = exonerations.compute([
      2 ('years_in_prison', agate.Change('convicted', 'exonerated')),
----> 3 ('full_name', agate.Formula(text_type, lambda row: '%(first_name)s %(last_name)s' % row))
      4 ])

/Users/nikhil/docs/learn/py/agate_tutorial/env/lib/python2.7/site-packages/agate/table.pyc in compute(self, computations)
    582             new_rows.append(tuple(row) + new_columns)
    583
--> 584         return self._fork(new_rows, zip(column_names, column_types))
    585
    586     def format(self, max_rows=None, max_columns=None):

/Users/nikhil/docs/learn/py/agate_tutorial/env/lib/python2.7/site-packages/agate/table.pyc in _fork(self, rows, column_info)
    124             column_info = zip(self._column_names, self._column_types)
    125
--> 126         return Table(rows, column_info)
    127
    128     @classmethod

/Users/nikhil/docs/learn/py/agate_tutorial/env/lib/python2.7/site-packages/agate/table.pyc in __init__(self, rows, column_info)
     85                 continue
     86
---> 87             cast_data.append(tuple(cast_funcs[i](d) for i, d in enumerate(row)))
     88
     89         self._data = tuple(cast_data)

/Users/nikhil/docs/learn/py/agate_tutorial/env/lib/python2.7/site-packages/agate/table.pyc in <genexpr>((i, d))
     85                 continue
     86
---> 87             cast_data.append(tuple(cast_funcs[i](d) for i, d in enumerate(row)))
     88
     89         self._data = tuple(cast_data)

/Users/nikhil/docs/learn/py/agate_tutorial/env/lib/python2.7/site-packages/agate/column_types.pyc in cast(self, d)
    197             return Decimal(d)
    198         except InvalidOperation:
--> 199             raise CastError('Can not convert value "%s" to Decimal for NumberColumn.' % d)
    200
    201     def _create_column(self, table, index):

CastError: Can not convert value "Joseph Lamont Abbitt" to Decimal for NumberColumn.
```