### PR TITLE
Add print_csv function to Table

### DIFF
--- a/agate/table.py
+++ b/agate/table.py
@@ -255,6 +255,16 @@ class Table(Patchable):
             if close:
                 f.close()
 
+    def print_csv(self, **kwargs):
+        """
+        A shortcut to printing a table as a csv. Effectively the same as
+        passing :meth:`sys.stdout` to :meth:`Table.to_csv`.
+
+        ``kwargs`` will be passed on to :meth:`Table.to_csv`.
+        """
+
+        self.to_csv(sys.stdout, **kwargs)
+
     @property
     def column_types(self):
         """
@@ -561,7 +571,7 @@ class Table(Patchable):
             # Rows without matches
             elif not inner:
                 new_row = list(self._rows[left_index])
-                
+
                 for k, v in enumerate(right_table.column_names):
                     if k == right_key_index:
                         continue

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -6,6 +6,11 @@ try:
 except ImportError: #pragma: no cover
     from decimal import Decimal
 
+try:
+    from StringIO import StringIO
+except ImportError:
+    from io import StringIO
+
 import os
 
 try:
@@ -247,6 +252,19 @@ class TestTable(unittest.TestCase):
         self.assertEqual(contents1, contents2)
 
         os.remove('.test.csv')
+
+    def test_to_csv_to_stdout(self):
+        table = Table(self.rows, self.columns)
+
+        output = StringIO()
+        table.to_csv(output)
+
+        contents1 = output.getvalue()
+
+        with open('examples/test.csv') as f:
+            contents2 = f.read()
+
+        self.assertEqual(contents1, contents2)
 
     def test_get_column_types(self):
         table = Table(self.rows, self.columns)


### PR DESCRIPTION
Hello! This addresses #307.

I added a function called `Table.print_csv` that serves as a shortcut to passing `sys.stdout` to `Table.to_csv` as its `path`. Still lets you pass in `**kwargs` if a user wants to get creative with the csv formatting.

Had to mess with `StringIO` to do (what I think) is the correct way to test this. Lemme know if I went about that correctly!