### PR TITLE
Implements from_json to Table method, requested feature.

### DIFF
--- a/agate/data_types/base.py
+++ b/agate/data_types/base.py
@@ -32,3 +32,5 @@ class DataType(object): #pragma: no cover
 
     def __ne__(self,other):
         return not self.__eq__(other)
+    def __hash__(self):
+        return id(self)

--- a/agate/data_types/base.py
+++ b/agate/data_types/base.py
@@ -25,3 +25,10 @@ class DataType(object): #pragma: no cover
         Coerce a given string value into this column's data type.
         """
         raise NotImplementedError
+
+    def __eq__(self,other):
+        return (isinstance(other, self.__class__)
+            and self.__dict__ == other.__dict__)
+
+    def __ne__(self,other):
+        return not self.__eq__(other)

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -184,7 +184,7 @@ class TestTable(unittest.TestCase):
         table2 = Table.from_json('examples/test.json')
 
         self.assertSequenceEqual(table1.column_names, table2.column_names)
-        # self.assertSequenceEqual(table1.column_types, table2.column_types)
+        self.assertSequenceEqual(table1.column_types, table2.column_types)
 
         self.assertEqual(len(table1.columns), len(table2.columns))
         self.assertEqual(len(table1.rows), len(table2.rows))
@@ -201,7 +201,7 @@ class TestTable(unittest.TestCase):
             table2 = Table.from_json(fh, self.columns)
 
             self.assertSequenceEqual(table1.column_names, table2.column_names)
-            # self.assertSequenceEqual(table1.column_types, table2.column_types)
+            self.assertSequenceEqual(table1.column_types, table2.column_types)
 
             self.assertEqual(len(table1.columns), len(table2.columns))
             self.assertEqual(len(table1.rows), len(table2.rows))


### PR DESCRIPTION
Proposed feature from Issue #344 and initial tests. Currently it only supports flat json items seperated by a new line, but it should probably be made to support a list too. May want to support nested dictionaries as well.