### PR TITLE
Edits to tutorial.rst

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -60,7 +60,7 @@ With no other arguments specified, agate will automatically create an instance o
 
 .. code-block:: python
 
-    tester = TypeTester(force={
+    tester = agate.TypeTester(force={
         'false_evidence': agate.Boolean()
     })
 
@@ -72,7 +72,7 @@ For larger datasets the :class:`.TypeTester` can be slow to evaluate the data. I
 
 .. code-block:: python
 
-    tester = TypeTester(limit=100)
+    tester = agate.TypeTester(limit=100)
 
     exonerations = agate.Table.from_csv('exonerations-20150828.csv', tester)
 

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -50,7 +50,7 @@ Now let's import our dependencies:
 Loading data from a CSV
 =======================
 
-The :class:`.Table` is the basic class in agate. To create a table from a CSV we use :meth:`.Table.from_csv`::
+The :class:`.Table` is the basic class in agate. To create a table from a CSV we use :meth:`.Table.from_csv`:
 
 .. code-block:: python
 


### PR DESCRIPTION
* Line 53 - Removes extra colon that prevented the code block from rendering
* Line 63 - Using example code verbatim returned ```NameError: name 'TypeTester' is not defined```. Using it as a method of agate fixes that. 
* Line 75 - Same as above.