### PR TITLE
Implements TableSet.to_json, Table.rename and updates TableSet csv functions

### DIFF
--- a/agate/table.py
+++ b/agate/table.py
@@ -26,6 +26,7 @@ from copy import copy
 from itertools import chain
 import json
 import sys
+import os.path
 
 try:
     from cdecimal import Decimal
@@ -304,12 +305,15 @@ class Table(utils.Patchable):
             kwargs['lineterminator'] = '\n'
 
         close = True
-
+        f = None
+        
         try:
             if hasattr(path, 'write'):
                 f = path
                 close = False
             else:
+                if os.path.dirname(path) and not os.path.exists(os.path.dirname(path)):
+                    os.makedirs(os.path.dirname(path))
                 f = open(path, 'w')
 
             writer = csv.writer(f, **kwargs)
@@ -320,7 +324,7 @@ class Table(utils.Patchable):
             for row in self._rows:
                 writer.writerow(tuple(csv_funcs[i](d) for i, d in enumerate(row)))
         finally:
-            if close:
+            if close and f is not None:
                 f.close()
 
     @classmethod
@@ -460,12 +464,15 @@ class Table(utils.Patchable):
         json_funcs = [c.jsonify for c in self._column_types]
 
         close = True
+        f = None
 
         try:
             if hasattr(path, 'write'):
                 f = path
                 close = False
             else:
+                if os.path.dirname(path) and not os.path.exists(os.path.dirname(path)):
+                    os.makedirs(os.path.dirname(path))
                 f = open(path, 'w')
 
             if six.PY2:
@@ -508,7 +515,7 @@ class Table(utils.Patchable):
 
                 dump_json(output)
         finally:
-            if close:
+            if close and f is not None:
                 f.close()
 
     @allow_tableset_proxy

--- a/agate/table.py
+++ b/agate/table.py
@@ -255,6 +255,32 @@ class Table(utils.Patchable):
 
         return Table(rows, column_names, column_types, row_names=row_names, _is_fork=True)
 
+    def _rename(self, column_names=None, row_names=None):
+        """
+        Creates a new table, but uses fork so rows are preserved. Either columns 
+        or rows can optionally be renamed. column_names can be either a sequence 
+        or a dict of replacements. row_names matches interface of Table().
+
+        :param column_names:
+            New column names for the renamed table. If not specified, fork will 
+            use this table's column names.
+        :param row_names:
+            New row names for the renamed table. If not specified, fork will use 
+            this table's row names.
+        """
+        if column_names is None:
+            column_names = self._column_names
+
+        if row_names is None:
+            row_names = self._row_names
+
+        if isinstance(column_names, dict):
+            names_from_dict = [column_names[name] if name in column_names else name for name in self.column_names]
+            
+            return self._fork(self.rows, names_from_dict, self._column_types, row_names=row_names)
+        else:    
+            return self._fork(self.rows, column_names, self._column_types, row_names=row_names)
+
     @classmethod
     def from_csv(cls, path, column_names=None, column_types=None, row_names=None, header=True, **kwargs):
         """

--- a/agate/tableset.py
+++ b/agate/tableset.py
@@ -169,7 +169,7 @@ class TableSet(MappedSequence, Patchable):
 
     def to_csv(self, dir_path, **kwargs):
         """
-        Write this each table in this set to a separate CSV in a given
+        Write each table in this set to a separate CSV in a given
         directory.
 
         See :meth:`.Table.to_csv` for additional details.
@@ -184,6 +184,24 @@ class TableSet(MappedSequence, Patchable):
             path = os.path.join(dir_path, '%s.csv' % name)
 
             table.to_csv(path, **kwargs)
+
+    def to_json(self, dir_path, **kwargs):
+        """
+        Write each table in this set to a separate JSON file in a given
+        directory.
+
+        See :meth:`.Table.to_json` for additional details.
+
+        :param dir_path:
+            Path to the directory to write the JSON files to.
+        """
+        if not os.path.exists(dir_path):
+            os.makedirs(dir_path)
+
+        for name, table in self.items():
+            path = os.path.join(dir_path, '%s.json' % name)
+
+            table.to_json(path, **kwargs)
 
     @property
     def column_types(self):

--- a/examples/tableset/table1.json
+++ b/examples/tableset/table1.json
@@ -1,0 +1,14 @@
+[
+    {
+      "letter": "a",
+      "number": 1
+    },
+    {
+      "letter": "a",
+      "number": 3
+    },
+    {
+      "letter": "b",
+      "number": 2
+    }
+]

--- a/examples/tableset/table2.json
+++ b/examples/tableset/table2.json
@@ -1,0 +1,14 @@
+[
+    {
+      "letter": "b",
+      "number": 0
+    },
+    {
+      "letter": "a",
+      "number": 2
+    },
+    {
+      "letter": "c",
+      "number": 5
+    }
+]

--- a/examples/tableset/table3.json
+++ b/examples/tableset/table3.json
@@ -1,0 +1,14 @@
+[
+    {
+      "letter": "a",
+      "number": 1
+    },
+    {
+      "letter": "a",
+      "number": 2
+    },
+    {
+      "letter": "c",
+      "number": 3
+    }
+]

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -575,6 +575,22 @@ class TestCSV(AgateTestCase):
             contents2 = f.read()
 
         self.assertEqual(contents1, contents2)
+    
+    def test_to_csv_make_dir(self):
+        table = Table(self.rows, self.column_names, self.column_types)
+
+        table.to_csv('newdir/test.csv')
+
+        with open('newdir/test.csv') as f:
+            contents1 = f.read()
+
+        with open('examples/test.csv') as f:
+            contents2 = f.read()
+
+        self.assertEqual(contents1, contents2)
+
+        os.remove('newdir/test.csv')
+        os.rmdir('newdir/')
 
     def test_print_csv(self):
         table = Table(self.rows, self.column_names, self.column_types)
@@ -732,6 +748,37 @@ class TestJSON(AgateTestCase):
         with self.assertRaises(ValueError):
             table.to_json(output, key='three', newline=True)
 
+    def test_to_json_file_output(self):
+        table = Table(self.rows, self.column_names, self.column_types)
+
+        table.to_json('.test.json')
+        
+        with open('.test.json') as f1:    
+            js1 = json.load(f1)
+
+        with open('examples/test.json') as f2:
+            js2 = json.load(f2)
+
+        self.assertEqual(js1, js2)
+
+        os.remove('.test.json')
+
+    def test_to_json_make_dir(self):
+        table = Table(self.rows, self.column_names, self.column_types)
+        
+        table.to_json('newdir/test.json')
+        
+        with open('newdir/test.json') as f1:    
+            js1 = json.load(f1)
+
+        with open('examples/test.json') as f2:
+            js2 = json.load(f2)
+
+        self.assertEqual(js1, js2)
+
+        os.remove('newdir/test.json')
+        os.rmdir('newdir/')
+        
     def test_print_json(self):
         table = Table(self.rows, self.column_names, self.column_types)
 

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -1569,3 +1569,19 @@ class TestData(AgateTestCase):
         self.assertIsNot(table2.rows[0], table3.rows[0])
         self.assertNotEqual(table2.rows[0], table3.rows[0])
         self.assertSequenceEqual(table.rows[0], (1, 4, 'a'))
+    
+    def test_rename(self):
+        table = Table(self.rows, self.column_names, self.column_types)
+        table2 = table._rename(row_names=['a','b','c'])
+        table3 = table._rename(column_names=['d','e','f'])
+
+        self.assertSequenceEqual(table2.row_names, ['a','b','c'])
+        self.assertSequenceEqual(table2.column_names, self.column_names)
+        self.assertIs(table3.row_names, None)
+        self.assertSequenceEqual(table3.column_names, ['d','e','f'])
+        
+    def test_rename_column_names_dict(self):
+        table = Table(self.rows, self.column_names, self.column_types)
+        table2 = table._rename(column_names={'two': 'second'})
+
+        self.assertSequenceEqual(table2.column_names, ['one','second','three'])

--- a/tests/test_tableset.py
+++ b/tests/test_tableset.py
@@ -8,6 +8,7 @@ except ImportError: #pragma: no cover
     from decimal import Decimal
 
 import shutil
+import json
 
 try:
     import unittest2 as unittest
@@ -90,6 +91,22 @@ class TestTableSet(AgateTestCase):
 
             with open('examples/tableset/%s.csv' % name) as f:
                 contents2 = f.read()
+
+            self.assertEqual(contents1, contents2)
+
+        shutil.rmtree('.test-tableset')
+
+    def test_to_json(self):
+        tableset = TableSet(self.tables.values(), self.tables.keys())
+
+        tableset.to_json('.test-tableset')
+
+        for name in ['table1', 'table2', 'table3']:
+            with open('.test-tableset/%s.json' % name) as f:
+                contents1 = json.load(f)
+
+            with open('examples/tableset/%s.json' % name) as f:
+                contents2 = json.load(f)
 
             self.assertEqual(contents1, contents2)
 


### PR DESCRIPTION
Create directory if output directory does not exist for Table.to_csv and Table.to_json. Closes #392
Implement Tableset.to_json. Closes #374.
Implement Table.rename. Closes #389

Side note: sorry for the multiple commits/features and title changes. I continued working on the master branch after opening the initial pull request. I'll be sure to open feature branches from now on. 