### PR TITLE
Add HTML rich display of Table instances in IPython

### DIFF
--- a/agate/table.py
+++ b/agate/table.py
@@ -256,6 +256,31 @@ class Table(utils.Patchable):
 
         return Table(rows, column_names, column_types, row_names=row_names, _is_fork=True)
 
+    def _repr_html_(self):
+        html = []
+
+        html.append('<table>')
+        html.append('<thead>')
+        html.append('<tr>')
+        for col in self.column_names:
+            html.append('<th>')
+            html.append(col)
+            html.append('</th>')
+        html.append('</tr>')
+        html.append('</thead>')
+        html.append('<tbody>')
+        for row in self.rows:
+            html.append('<tr>')
+            for col in row:
+                html.append('<td>')
+                html.append(six.text_type(col))
+                html.append('</td>')
+            html.append('</tr>')
+        html.append('</tbody>')
+        html.append('</table>')
+
+        return ''.join(html)
+
     def rename(self, column_names=None, row_names=None):
         """
         Creates a copy of this table with different column or row names.


### PR DESCRIPTION
IPython, and in particular IPython/Jupyter notebooks provide rich
display of objects.  See
http://ipython.readthedocs.org/en/stable/config/integrating.html?highlight=_repr_html_#rich-display
for more information.

Implement a `agate.Table._repr_html_()` method to render the
agate Table as HTML in the notebook.

Addresses https://github.com/onyxfish/agate/issues/408