### PR TITLE
Fixes row keys not changing on Table.rename with new column names

### DIFF
--- a/agate/table.py
+++ b/agate/table.py
@@ -279,7 +279,7 @@ class Table(utils.Patchable):
             New row names for the renamed table. May be either an array or
             a dictionary mapping existing row names to new names. If not
             specified, will use this table's existing row names.
-        """    
+        """
         if isinstance(column_names, dict):
             column_names = [column_names[name] if name in column_names else name for name in self.column_names]
 
@@ -289,9 +289,6 @@ class Table(utils.Patchable):
         if column_names is not None and column_names != self.column_names:
             if row_names is None:
                 row_names = self._row_names
-            
-            if column_names is None:
-                column_names = self._column_names
                 
             return Table(self.rows, column_names, self.column_types, row_names=row_names, _is_fork=False)
         else:

--- a/agate/table.py
+++ b/agate/table.py
@@ -279,14 +279,23 @@ class Table(utils.Patchable):
             New row names for the renamed table. May be either an array or
             a dictionary mapping existing row names to new names. If not
             specified, will use this table's existing row names.
-        """
+        """    
         if isinstance(column_names, dict):
             column_names = [column_names[name] if name in column_names else name for name in self.column_names]
 
         if isinstance(row_names, dict):
             row_names = [row_names[name] if name in row_names else name for name in self.row_names]
-
-        return self._fork(self.rows, column_names, self._column_types, row_names=row_names)
+        
+        if column_names is not None and column_names != self.column_names:
+            if row_names is None:
+                row_names = self._row_names
+            
+            if column_names is None:
+                column_names = self._column_names
+                
+            return Table(self.rows, column_names, self.column_types, row_names=row_names, _is_fork=False)
+        else:
+            return self._fork(self.rows, column_names, self._column_types, row_names=row_names)
 
     @classmethod
     def from_csv(cls, path, column_names=None, column_types=None, row_names=None, header=True, **kwargs):

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -1723,6 +1723,14 @@ class TestData(AgateTestCase):
 
         self.assertIs(table.row_names, None)
         self.assertSequenceEqual(table.column_names, self.column_names)
+    
+    def test_rename_column_names_renames_row_values(self):
+        table = Table(self.rows, self.column_names, self.column_types)
+        new_column_names = ['d', 'e', 'f']
+        table2 = table.rename(column_names=new_column_names)
+        for row, row2 in zip(table.rows, table2.rows):
+            for key, key2 in zip(self.column_names, new_column_names):
+                self.assertEqual(row[key], row2[key2])
 
 
 class TableHTMLParser(html_parser.HTMLParser):


### PR DESCRIPTION
Use init instead of fork in Table.rename when column_names are changed. Include @ghing's test for row key change. Closes #423