### PR TITLE
typo: using by using -> using

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -431,7 +431,7 @@ First, we use :meth:`.Table.group_by` to group the data by state.
 
     by_state = exonerations.group_by('state')
 
-This takes our original :class:`.Table` and groups it into a :class:`.TableSet`, which contains one table per county. As mentioned much earlier in this tutorial, TableSet's are instances of :class:`.MappedSequence`. That means that work very much like :class:`.Column` and :class:`.Row`.
+This takes our original :class:`.Table` and groups it into a :class:`.TableSet`, which contains one table per county. As mentioned much earlier in this tutorial, TableSets are instances of :class:`.MappedSequence`. That means they work very much like :class:`.Column` and :class:`.Row`.
 
 Now we need to aggregate the total for each state. This works in a very similar way to how it did when we were aggregating columns of a single table, except that we'll use the :class:`.Length` aggregation to count the total number of values in the table.
 

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -194,7 +194,7 @@ Q: **How many exonerations involved a false confession?**
 
 Answering this question involves counting the number of ``True`` values in the ``false_confession`` column. When we created the table we specified that the data in this column contained :class:`.Boolean` data. Because of this, agate has taken care of coercing the original text data from the CSV into Python's ``True`` and ``False`` values.
 
-We'll answer the question using by using an instance of :class:`.Count` which is a type of :class:`.Aggregation`. Aggregations are used to perform "column-wise" calculations. That is, they derive a new single value from the contents of a column. In the case of :class:`.Count`, it will tell us how many times a particular value appears in the column.
+We'll answer the question using an instance of :class:`.Count` which is a type of :class:`.Aggregation`. Aggregations are used to perform "column-wise" calculations. That is, they derive a new single value from the contents of a column. In the case of :class:`.Count`, it will tell us how many times a particular value appears in the column.
 
 An Aggregation is applied to a table using :meth:`.Table.aggregate`.
 


### PR DESCRIPTION
Fix trivial typo in user tutorial.
(update: added a few more)